### PR TITLE
Fix enum setLabel logic

### DIFF
--- a/projex/enum.py
+++ b/projex/enum.py
@@ -210,7 +210,7 @@ class enum(dict):
         :param      value | <variant>
                     label | <str>
         """
-        if value:
+        if label:
             self._labels[value] = label
         else:
             self._labels.pop(value, None)


### PR DESCRIPTION
Sets the label when it is not the empty string or None (or anything that evals to False), unset it otherwise.
